### PR TITLE
Allow using override to add features

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -72,7 +72,7 @@ backend.auth.cmd = "pass show example-imap"
 
 # IMAP server OAuth 2.0 authorization configuration.
 #
-#right.backend.auth.type = "oauth2"
+#backend.auth.type = "oauth2"
 #
 # Client identifier issued to the client during the registration
 # process described in RFC6749.

--- a/default.nix
+++ b/default.nix
@@ -5,15 +5,11 @@
 pimalaya.mkDefault ({
   src = ./.;
   version = "1.0.0";
-  mkPackage = ({ lib, pkgs, rustPlatform, defaultFeatures, features }: import ./package.nix {
+  mkPackage = ({ lib, pkgs, rustPlatform, defaultFeatures, features }: pkgs.callPackage ./package.nix {
     inherit lib rustPlatform;
-    fetchFromGitHub = pkgs.fetchFromGitHub;
-    stdenv = pkgs.stdenv;
     apple-sdk = if pkgs.hostPlatform.isx86_64 then pkgs.apple-sdk_13 else pkgs.apple-sdk_14;
-    installShellFiles = pkgs.installShellFiles;
     installShellCompletions = false;
     installManPages = false;
-    pkg-config = pkgs.pkg-config;
     buildNoDefaultFeatures = !defaultFeatures;
     buildFeatures = lib.splitString "," features;
   });


### PR DESCRIPTION
This way you can do
```nix
mirador.override {
  buildFeatures = [ "oauth2" ];
}
```

Also this uses any unspecified arguments as if they were given from
`pkgs`, so no need to explicitly specify.

See also pimalaya/neverest#15 pimalaya/himalaya#511